### PR TITLE
Use current_branch in ProjectDiff to avoid detached head

### DIFF
--- a/lib/lintrunner/runner/project_diff.rb
+++ b/lib/lintrunner/runner/project_diff.rb
@@ -7,10 +7,10 @@ module Lintrunner
         before_messages = []
         after_messages = []
         Dir.chdir(path) do
-          prev_sha = git.head.target
+          prev_branch = current_branch
           `git checkout -q #{git_common_ancestor}`
           before_messages = executor.execute(nil)
-          `git checkout -q #{prev_sha}`
+          `git checkout -q #{prev_branch}`
           after_messages = executor.execute(nil)
         end
 


### PR DESCRIPTION
We already have logic in our GitHelper module for gracefully determining the current branch (falls back to SHA), we can utilize this method in our ProjectDiff runner to avoid putting the user in a detached head state after execution. 

---

Use existing `current_branch` logic in ProjectDiff runner.

* Prevents checking out a detached sha after executing. If there is
no branch, it falls back to the sha.